### PR TITLE
Don't try to build as a variable font

### DIFF
--- a/sources/config.yaml
+++ b/sources/config.yaml
@@ -1,3 +1,4 @@
 sources:
   - Brawler.glyphs
 familyName: Brawler
+buildVariable: false


### PR DESCRIPTION
The masters of this font aren't currently interpolatable (it wouldn't take much to make them be, but that's an issue for another time), but currently the gftools-builder assumes they are and tries to build it as a variable font. The `buildVariable` option should be turned off to prevent this.